### PR TITLE
Get a team's bots

### DIFF
--- a/app/controllers/api/v1/teams/bots_controller.rb
+++ b/app/controllers/api/v1/teams/bots_controller.rb
@@ -3,13 +3,16 @@ module Api
     module Teams
       class BotsController < ApplicationController
         def create
-          bots = @team.generate_bots
-
-          if bots
-            render json: BotSerializer.new(bots), status: :created
+          if @team.bots.empty?
+            render json: BotSerializer.new(@team.generate_bots),
+                   status: :created
           else
-            render json: bots.errors.full_messages.to_sentence
+            render json: { error: 'Bots already generated' }, status: :conflict
           end
+        end
+
+        def index
+          render json: BotSerializer.new(@team.bots), status: :ok
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
       resources :teams, only: [:create, :update]
 
       namespace :teams do
-        resources :bots, only: [:create]
+        resources :bots, only: [:index]
+        post '/generate_bots', to: 'bots#create'
         post '/generate_roster', to: 'rosters#generate_roster'
       end
 

--- a/spec/requests/api/v1/bots/get_bots_request_spec.rb
+++ b/spec/requests/api/v1/bots/get_bots_request_spec.rb
@@ -1,16 +1,17 @@
 require 'rails_helper'
 
-describe 'Generate bots request' do
+describe 'Get teams bots request' do
   let!(:new_team) { create :team }
 
-  context 'with a valid token' do
-    it 'returns 100 bots with unique attributes' do
+  context 'with valid token' do
+    it 'returns the teams bots' do
       auth_team(new_team)
+      new_team.generate_bots
 
-      post '/api/v1/teams/generate_bots'
+      get '/api/v1/teams/bots'
 
       expect(response).to be_successful
-      expect(response.status).to eq(201)
+      expect(response.status).to eq(200)
 
       bots = JSON.parse(response.body)
 
@@ -24,25 +25,9 @@ describe 'Generate bots request' do
     end
   end
 
-  context 'Bots already generated' do
-    it 'returns error message' do
-      new_team.generate_bots
-      auth_team(new_team)
-
-      post '/api/v1/teams/generate_bots'
-
-      expect(response).to_not be_successful
-      expect(response.status).to eq(409)
-
-      error = JSON.parse(response.body)
-
-      expect(error['error']).to eq('Bots already generated')
-    end
-  end
-
   context 'Without valid token' do
     it 'returns error message' do
-      post '/api/v1/teams/generate_bots'
+      get '/api/v1/teams/bots'
 
       expect(response).to_not be_successful
       expect(response.status).to eq(401)


### PR DESCRIPTION
#### What does this PR do?

- Adds endpoint to get a team's bots
- Updates route for bot create action to `/generate_bots`
- Creates/updates specs

#### How should this be manually tested?

- Create team in `rails c`:
```ruby
team = Team.create(email: 'space@jam.com', password: 'password', name: 'Space Jam')

# generate bots
team.generate_bots
```
- Start server with `rails s`
- Make POST request via Postman to `/api/v1/login` with `params`:
  - `email: space@jam.com`
  - `password: password`

- Make GET request via Postman to `/api/v1/team/bots` with `Bearer Token` from `/login` response
- Successful request will return team's bots

#### What are the relevant tickets?

Closes #19

#### Screenshots (if appropriate)

#### Questions:
  - Do Migrations Need to be ran? NO
  - Do Environment Variables need to be set? NO
  - Any other deploy steps? NO
