### PR TITLE
Get a team's roster

### DIFF
--- a/app/controllers/api/v1/teams/rosters_controller.rb
+++ b/app/controllers/api/v1/teams/rosters_controller.rb
@@ -13,6 +13,10 @@ module Api
             render json: { error: 'Please generate bots' }, status: :conflict
           end
         end
+
+        def index
+          render json: RosterSerializer.new(@team.current_roster), status: :ok
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
         resources :bots, only: [:index]
         post '/generate_bots', to: 'bots#create'
         post '/generate_roster', to: 'rosters#generate_roster'
+        get '/roster', to: 'rosters#index'
       end
 
       post '/login', to: 'auth#login'

--- a/spec/requests/api/v1/rosters/get_roster_request_spec.rb
+++ b/spec/requests/api/v1/rosters/get_roster_request_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe 'Get roster request' do
+  let!(:team) { create :team }
+
+  context 'with valid token' do
+    it 'returns my teams roster' do
+      auth_team(team)
+      team.generate_bots
+      team.generate_roster
+
+      get '/api/v1/teams/roster'
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      roster = JSON.parse(response.body)
+
+      expect(roster['data'].size).to eq(15)
+      expect(roster['data'][0]).to have_key('id')
+      expect(roster['data'][0]['type']).to eq('roster')
+      expect(roster['data'][0]['attributes']).to have_key('team')
+      expect(roster['data'][0]['attributes']).to have_key('role')
+      expect(roster['data'][0]['attributes']).to have_key('total_stats')
+      expect(roster['data'][0]['attributes']).to have_key('bot')
+    end
+  end
+
+  context 'Without valid token' do
+    it 'returns error message' do
+      get '/api/v1/teams/roster'
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(401)
+
+      error = JSON.parse(response.body)
+
+      expect(error['error']).to eq('Please Login')
+    end
+  end
+end


### PR DESCRIPTION
#### What does this PR do?

- Adds endpoint to get a team's roster
- Creates spec

#### How should this be manually tested?

- Create team in `rails c`:
```ruby
team = Team.create(email: 'space@jam.com', password: 'password', name: 'Space Jam')

# generate bots
team.generate_bots

# generate roster
team.generate_roster
```
- Start server with `rails s`
- Make POST request via Postman to `/api/v1/login` with `params`:
  - `email: space@jam.com`
  - `password: password`

- Make GET request via Postman to `/api/v1/team/roster` with `Bearer Token` from `/login` response
- Successful request will return team's roster

#### What are the relevant tickets?

Closes #6 

#### Screenshots (if appropriate)

#### Questions:
  - Do Migrations Need to be ran? NO
  - Do Environment Variables need to be set? NO
  - Any other deploy steps? NO
