### PR TITLE
Delete roster request

### DIFF
--- a/app/controllers/api/v1/teams/rosters_controller.rb
+++ b/app/controllers/api/v1/teams/rosters_controller.rb
@@ -42,6 +42,12 @@ module Api
           render json: RosterSerializer.new(@team.current_roster),
                  status: :ok
         end
+
+        def destroy
+          @team.delete_roster
+
+          render json: { message: 'Roster has been deleted.' }, status: :ok
+        end
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
         get '/roster', to: 'rosters#index'
         post '/roster', to: 'rosters#create'
         patch '/roster', to: 'rosters#update'
+        delete '/roster', to: 'rosters#destroy'
       end
 
       resources :teams, only: [:create, :update]

--- a/spec/requests/api/v1/rosters/delete_roster_request_spec.rb
+++ b/spec/requests/api/v1/rosters/delete_roster_request_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe 'Delete roster request' do
+  let!(:team) { create :team }
+
+  context 'with valid token' do
+    it 'returns message for successful delete' do
+      auth_team(team)
+      team.generate_bots
+      team.generate_roster
+
+      expect(team.current_roster.present?).to be(true)
+
+      delete '/api/v1/teams/roster'
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      message = JSON.parse(response.body)
+
+      expect(message['message']).to eq('Roster has been deleted.')
+
+      expect(team.current_roster.empty?).to be(true)
+    end
+  end
+
+  context 'Without valid token' do
+    it 'returns error message' do
+      delete '/api/v1/teams/roster'
+
+      expect(response).to_not be_successful
+      expect(response.status).to eq(401)
+
+      error = JSON.parse(response.body)
+
+      expect(error['error']).to eq('Please Login')
+    end
+  end
+end


### PR DESCRIPTION
#### What does this PR do?

- Adds endpoint to delete a team's roster
- Creates spec

#### How should this be manually tested?

- Create team in `rails c`:
```ruby
team = Team.create(email: 'space@jam.com', password: 'password', name: 'Space Jam')

# generate bots
team.generate_bots

# generate roster
team.generate_roster
```
- Start server with `rails s`
- Make POST request via Postman to `/api/v1/login` with `params`:
  - `email: space@jam.com`
  - `password: password`

- Make DELETE request via Postman to `/api/v1/team/roster` with `Bearer Token` from `/login` response and `params`:

- Successful request will return message stating roster has been deleted

#### What are the relevant tickets?

Closes #10 

#### Screenshots (if appropriate)

#### Questions:
  - Do Migrations Need to be ran? NO
  - Do Environment Variables need to be set? NO
  - Any other deploy steps? NO
