### PR TITLE
feat(rosters): Update controller

### DIFF
--- a/app/controllers/api/v1/teams/rosters_controller.rb
+++ b/app/controllers/api/v1/teams/rosters_controller.rb
@@ -14,8 +14,12 @@ module Api
           end
         end
 
+        def current_roster
+          render json: RosterSerializer.new(current_team.current_roster)
+        end
+
         def index
-          render json: RosterSerializer.new(current_team.current_roster),
+          render json: RosterSerializer.new(current_team.rosters),
                  status: :ok
         end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
         resources :bots, only: [:index]
         post '/generate_bots', to: 'bots#create'
         post '/generate_roster', to: 'rosters#generate_roster'
+        get '/current_roster', to: 'rosters#current_roster'
         get '/roster', to: 'rosters#index'
         patch '/roster/:id', to: 'rosters#update'
         delete '/roster', to: 'rosters#destroy'

--- a/spec/requests/api/v1/rosters/current_roster_request_spec.rb
+++ b/spec/requests/api/v1/rosters/current_roster_request_spec.rb
@@ -1,21 +1,22 @@
 require 'rails_helper'
 
-describe 'Get roster request' do
+describe 'Get current roster request' do
   let!(:team) { create :team }
 
   context 'with valid token' do
-    it 'returns my teams entire roster' do
+    it 'returns my teams roster' do
       auth_team(team)
       team.generate_bots
+      team.generate_roster
 
-      get '/api/v1/teams/roster'
+      get '/api/v1/teams/current_roster'
 
       expect(response).to be_successful
       expect(response.status).to eq(200)
 
       roster = JSON.parse(response.body)
 
-      expect(roster['data'].size).to eq(100)
+      expect(roster['data'].size).to eq(15)
       expect(roster['data'][0]).to have_key('id')
       expect(roster['data'][0]['type']).to eq('roster')
       expect(roster['data'][0]['attributes']).to have_key('team')
@@ -27,7 +28,7 @@ describe 'Get roster request' do
 
   context 'Without valid token' do
     it 'returns error message' do
-      get '/api/v1/teams/roster'
+      get '/api/v1/teams/current_roster'
 
       expect(response).to_not be_successful
       expect(response.status).to eq(401)


### PR DESCRIPTION
#### What does this PR do?

- Update index action to return entire roster including
  benchwarmers for edit page on client
- Adds current_roster endpoint
- Updates/creates specs

#### How should this be manually tested?

- Create team in `rails c`:
```ruby
team = Team.create(email: 'space@jam.com', password: 'password', name: 'Space Jam')

# generate bots
team.generate_bots

# generate roster
team.generate_roster
```
- Start server with `rails s`
- Make POST request via Postman to `/api/v1/login` with `params`:
  - `email: space@jam.com`
  - `password: password`

- Make GET request via Postman to `/api/v1/team/roster` with `Bearer Token` from `/login` response
- Successful request will return team's entire roster including benchwarmers

- Make GET request via Postman to `/api/v1/team/current_roster` with `Bearer Token` from `/login` response
- Successful request will return team's entire roster with 10 starters and 5 alternates

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Questions:
  - Do Migrations Need to be ran? NO
  - Do Environment Variables need to be set? NO
  - Any other deploy steps? NO
